### PR TITLE
fix: [PhU-391] Incorrect help text for Year of birth field

### DIFF
--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -307,7 +307,7 @@ const messages = defineMessages({
   },
   'account.settings.field.year.of.birth.help.text': {
     id: 'account.settings.field.year.of.birth.help.text',
-    defaultMessage: 'You must be 16 years old or above to have an account with {siteName}.',
+    defaultMessage: 'You must be 16 years old or older to have an account with {siteName}.',
     description: 'Help text for the account settings year of birth field.',
   },
   'account.settings.field.secondary.email': {


### PR DESCRIPTION
## YouTrack:
- https://youtrack.raccoongang.com/issue/PhU-391